### PR TITLE
Initial coding style configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+---
+BasedOnStyle: WebKit
+AlignAfterOpenBracket: Align
+AlignTrailingComments: true
+FixNamespaceComments: true
+SortIncludes: false
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never
+
+...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = 1
+trim_trailing_whitespace = 1


### PR DESCRIPTION
[Editorconfig]: UTF8 encoding with a space of 4 indentation, removing line trailing spaces and a newline ending every file

[clang-format] based on [WebKit] coding style
- horizontally aligns arguments after an open bracket
- aligns trailing comments
- adds missing namespace end comments for short namespaces and fixes invalid existing ones
- includes are never sorted

see also [clang-format-configurator].

[Editorconfig]: https://editorconfig.org/
[clang-format]: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
[clang-format-configurator]: https://zed0.co.uk/clang-format-configurator/
[WebKit]: https://webkit.org/code-style-guidelines/
